### PR TITLE
Fix location filter to include activities without a location

### DIFF
--- a/convex/activities.ts
+++ b/convex/activities.ts
@@ -376,9 +376,17 @@ export const getRecommendation = query({
           }
         }
 
-        // Filter by location if enabled
-        if (nearbyActivityIds && !nearbyActivityIds.has(activity._id.toString())) {
-          return false;
+        // Filter by location if enabled (still include activities with no location)
+        if (nearbyActivityIds) {
+          const hasCoordinates =
+            activity.location?.latitude != null &&
+            activity.location?.longitude != null;
+          if (
+            hasCoordinates &&
+            !nearbyActivityIds.has(activity._id.toString())
+          ) {
+            return false;
+          }
         }
 
         return true;


### PR DESCRIPTION
When location filtering is enabled, activities with no coordinates
(e.g. at-home activities) were being excluded because they were never
in the geospatial index. Now only activities that have coordinates are
filtered by proximity — locationless activities always pass through.

https://claude.ai/code/session_019SKpQnSbwgnkg3EGE9CEpJ