### PR TITLE
feat: change-tracking pipeline for scraping sources

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -9,6 +9,8 @@
  */
 
 import type * as activities from "../activities.js";
+import type * as changeTracking from "../changeTracking.js";
+import type * as crons from "../crons.js";
 import type * as embeddings from "../embeddings.js";
 import type * as env from "../env.js";
 import type * as formatting from "../formatting.js";
@@ -20,6 +22,8 @@ import type * as otelServer from "../otelServer.js";
 import type * as quiz from "../quiz.js";
 import type * as scrapeWorkflow from "../scrapeWorkflow.js";
 import type * as scraping from "../scraping.js";
+import type * as scrapingSourceItems from "../scrapingSourceItems.js";
+import type * as scrapingSources from "../scrapingSources.js";
 import type * as storageHelpers from "../storageHelpers.js";
 import type * as tags from "../tags.js";
 import type * as userActivityPreferences from "../userActivityPreferences.js";
@@ -33,6 +37,8 @@ import type {
 
 declare const fullApi: ApiFromModules<{
   activities: typeof activities;
+  changeTracking: typeof changeTracking;
+  crons: typeof crons;
   embeddings: typeof embeddings;
   env: typeof env;
   formatting: typeof formatting;
@@ -44,6 +50,8 @@ declare const fullApi: ApiFromModules<{
   quiz: typeof quiz;
   scrapeWorkflow: typeof scrapeWorkflow;
   scraping: typeof scraping;
+  scrapingSourceItems: typeof scrapingSourceItems;
+  scrapingSources: typeof scrapingSources;
   storageHelpers: typeof storageHelpers;
   tags: typeof tags;
   userActivityPreferences: typeof userActivityPreferences;

--- a/convex/changeTracking.ts
+++ b/convex/changeTracking.ts
@@ -1,0 +1,384 @@
+"use node";
+
+import { gunzipSync } from "node:zlib";
+import { XMLParser } from "fast-xml-parser";
+import { Firecrawl } from "@mendable/firecrawl-js";
+import { v } from "convex/values";
+import { internalAction } from "./_generated/server";
+import { internal, api } from "./_generated/api";
+import type { Doc } from "./_generated/dataModel";
+import { env } from "./env";
+
+// -------------------------------------------------------------------------
+// Types
+// -------------------------------------------------------------------------
+
+type Source = Doc<"scrapingSources">;
+type SeenItem = Doc<"scrapingSourceItems">;
+type Discovered = { url: string; lastmod?: string; contentHash?: string };
+
+type DetectionResult = {
+  newUrls: Discovered[];
+  updatedUrls: Discovered[];
+};
+
+// -------------------------------------------------------------------------
+// Cron tick — schedules detection for every active, due source
+// -------------------------------------------------------------------------
+
+export const tick = internalAction({
+  args: {},
+  returns: v.null(),
+  handler: async (ctx) => {
+    const now = Date.now();
+    const due = (await ctx.runQuery(internal.scrapingSources.listDue, {
+      now,
+    })) as Source[];
+
+    for (const source of due) {
+      await ctx.scheduler.runAfter(
+        0,
+        internal.changeTracking.detectChanges,
+        { sourceId: source._id },
+      );
+    }
+    return null;
+  },
+});
+
+// -------------------------------------------------------------------------
+// Dispatcher — runs the right detector, persists items, schedules Tier 2
+// -------------------------------------------------------------------------
+
+export const detectChanges = internalAction({
+  args: { sourceId: v.id("scrapingSources") },
+  returns: v.object({
+    newCount: v.number(),
+    updatedCount: v.number(),
+  }),
+  handler: async (ctx, { sourceId }) => {
+    const source = (await ctx.runQuery(internal.scrapingSources.get, {
+      sourceId,
+    })) as Source | null;
+    if (!source) throw new Error(`source ${sourceId} not found`);
+
+    const seenRows = (await ctx.runQuery(
+      internal.scrapingSourceItems.listBySource,
+      { sourceId },
+    )) as SeenItem[];
+    const seen = new Map(seenRows.map((r) => [r.url, r] as const));
+
+    let result: DetectionResult;
+    switch (source.detector.kind) {
+      case "sitemap":
+        result = await detectViaSitemap(source.detector, seen);
+        break;
+      case "rss":
+        result = await detectViaRss(source.detector, seen);
+        break;
+      case "firecrawl-change":
+        result = await detectViaFirecrawl(source.detector, seen);
+        break;
+    }
+
+    const now = Date.now();
+    const allDiscovered = [...result.newUrls, ...result.updatedUrls];
+
+    // Persist seen-set updates (new rows + bump lastSeenAt on existing).
+    if (allDiscovered.length > 0) {
+      await ctx.runMutation(internal.scrapingSourceItems.upsertBatch, {
+        sourceId,
+        items: allDiscovered,
+        now,
+      });
+    }
+
+    // Bookkeeping — always bump lastCheckedAt; bump lastChangeAt iff changes.
+    await ctx.runMutation(internal.scrapingSources.markChecked, {
+      sourceId,
+      checkedAt: now,
+      changed: allDiscovered.length > 0,
+    });
+
+    // Tier 2 dispatch — fire off a single-URL scrape per discovered item.
+    for (const item of allDiscovered) {
+      const workflowId = (await ctx.runMutation(
+        api.scrapeWorkflow.startSingleScrape,
+        {
+          url: item.url,
+          scraper: source.detailScrapeOptions?.scraper,
+          tagsHint: source.detailScrapeOptions?.tagsHint,
+          workflowConfig: { autoImport: true },
+          source: { sourceId, url: item.url },
+        },
+      )) as string;
+
+      await ctx.runMutation(internal.scrapingSourceItems.markQueued, {
+        sourceId,
+        url: item.url,
+        detailWorkflowId: workflowId,
+      });
+    }
+
+    return {
+      newCount: result.newUrls.length,
+      updatedCount: result.updatedUrls.length,
+    };
+  },
+});
+
+// -------------------------------------------------------------------------
+// RSS / Atom detector
+// -------------------------------------------------------------------------
+
+type RssDetector = Extract<Source["detector"], { kind: "rss" }>;
+
+async function detectViaRss(
+  detector: RssDetector,
+  seen: Map<string, SeenItem>,
+): Promise<DetectionResult> {
+  const entries = await fetchFeedEntries(detector.feedUrl);
+
+  const newUrls: Discovered[] = [];
+  const updatedUrls: Discovered[] = [];
+  for (const e of entries) {
+    if (!e.url) continue;
+    const prior = seen.get(e.url);
+    if (!prior) {
+      newUrls.push({ url: e.url, lastmod: e.lastmod });
+    } else if (e.lastmod && prior.lastmod !== e.lastmod) {
+      updatedUrls.push({ url: e.url, lastmod: e.lastmod });
+    }
+  }
+
+  return { newUrls, updatedUrls };
+}
+
+type FeedEntry = { url?: string; lastmod?: string };
+
+/**
+ * Parses both RSS 2.0 (`<rss><channel><item>`) and Atom (`<feed><entry>`).
+ * Attributes are kept because Atom links carry the URL in `href`.
+ */
+async function fetchFeedEntries(feedUrl: string): Promise<FeedEntry[]> {
+  const res = await fetch(feedUrl, {
+    headers: { "User-Agent": "TinyTripperBot/1.0 (+change-tracking)" },
+  });
+  if (!res.ok) {
+    throw new Error(`feed fetch failed: ${feedUrl} → HTTP ${res.status}`);
+  }
+  const body = await res.text();
+
+  type RssItem = { link?: string; pubDate?: string; "dc:date"?: string };
+  type AtomEntry = {
+    link?: AtomLink | AtomLink[];
+    updated?: string;
+    published?: string;
+  };
+
+  const parser = new XMLParser({ ignoreAttributes: false });
+  const parsed = parser.parse(body) as {
+    rss?: { channel?: { item?: RssItem | RssItem[] } };
+    feed?: { entry?: AtomEntry | AtomEntry[] };
+  };
+
+  // RSS 2.0
+  if (parsed.rss?.channel) {
+    return arr(parsed.rss.channel.item).map((item) => ({
+      url: typeof item.link === "string" ? item.link : undefined,
+      lastmod: item.pubDate ?? item["dc:date"],
+    }));
+  }
+
+  // Atom
+  if (parsed.feed) {
+    return arr(parsed.feed.entry).map((entry) => ({
+      url: pickAtomLink(entry.link),
+      lastmod: entry.updated ?? entry.published,
+    }));
+  }
+
+  return [];
+}
+
+type AtomLink = { "@_href"?: string; "@_rel"?: string };
+
+/** Atom entries can carry multiple <link>s; prefer rel="alternate". */
+function pickAtomLink(link: AtomLink | AtomLink[] | undefined): string | undefined {
+  const links = arr(link);
+  if (links.length === 0) return undefined;
+  const alternate = links.find((l) => l["@_rel"] === "alternate" || !l["@_rel"]);
+  return (alternate ?? links[0])["@_href"];
+}
+
+// -------------------------------------------------------------------------
+// Firecrawl change-tracking detector
+// -------------------------------------------------------------------------
+
+type FirecrawlDetector = Extract<
+  Source["detector"],
+  { kind: "firecrawl-change" }
+>;
+
+/**
+ * Scrapes the listing page once with Firecrawl's `changeTracking` + `json`
+ * formats. Firecrawl maintains its own previous snapshot, but we diff the
+ * *current* item list against our own seen set — that's the source of truth
+ * for what we've already scraped, and it stays correct even if Firecrawl's
+ * snapshot is reset. The configured schema describes an `items` array.
+ */
+async function detectViaFirecrawl(
+  detector: FirecrawlDetector,
+  seen: Map<string, SeenItem>,
+): Promise<DetectionResult> {
+  const itemsSchema = JSON.parse(detector.schemaJson) as Record<
+    string,
+    unknown
+  >;
+
+  const firecrawl = new Firecrawl({ apiKey: env.FIRECRAWL_API_KEY });
+
+  const doc = (await firecrawl.scrape(detector.listingUrl, {
+    // markdown is required: changeTracking compares pages via their markdown.
+    formats: [
+      "markdown",
+      { type: "json", schema: itemsSchema },
+      { type: "changeTracking", modes: ["json"], schema: itemsSchema },
+    ],
+  })) as {
+    json?: { items?: Array<{ url?: string; title?: string }> };
+    changeTracking?: {
+      json?: { items?: { current?: Array<{ url?: string }> } };
+    };
+  };
+
+  // Prefer the change-tracking "current" list; fall back to the plain json
+  // extraction if change tracking didn't populate (e.g. first ever scrape).
+  const currentItems =
+    doc.changeTracking?.json?.items?.current ?? doc.json?.items ?? [];
+
+  const newUrls: Discovered[] = [];
+  for (const item of currentItems) {
+    if (!item.url) continue;
+    if (!seen.has(item.url)) {
+      newUrls.push({ url: item.url });
+    }
+  }
+
+  // Firecrawl items carry no per-item lastmod, so we can't detect content
+  // updates to an already-seen URL here — only genuinely new URLs.
+  return { newUrls, updatedUrls: [] };
+}
+
+// -------------------------------------------------------------------------
+// Sitemap detector
+// -------------------------------------------------------------------------
+
+type SitemapDetector = Extract<Source["detector"], { kind: "sitemap" }>;
+
+async function detectViaSitemap(
+  detector: SitemapDetector,
+  seen: Map<string, SeenItem>,
+): Promise<DetectionResult> {
+  const urls = await walkSitemap(detector.sitemapUrl);
+
+  const filtered = urls.filter((u) => {
+    if (detector.pathIncludes && !u.loc.includes(detector.pathIncludes)) {
+      return false;
+    }
+    if (
+      detector.pathExcludes &&
+      detector.pathExcludes.some((p) => u.loc.includes(p))
+    ) {
+      return false;
+    }
+    return true;
+  });
+
+  const newUrls: Discovered[] = [];
+  const updatedUrls: Discovered[] = [];
+  for (const u of filtered) {
+    const prior = seen.get(u.loc);
+    if (!prior) {
+      newUrls.push({ url: u.loc, lastmod: u.lastmod });
+    } else if (u.lastmod && prior.lastmod !== u.lastmod) {
+      updatedUrls.push({ url: u.loc, lastmod: u.lastmod });
+    }
+  }
+
+  return { newUrls, updatedUrls };
+}
+
+type SitemapEntry = { loc: string; lastmod?: string };
+
+/**
+ * Walks a sitemap URL recursively:
+ * - `<sitemapindex>` → fetches each child sitemap and concatenates results.
+ * - `<urlset>` → returns the leaf entries.
+ *
+ * Transparently handles `.gz` and the whatson.melbourne.vic.gov.au quirk
+ * where the server returns 200 with an empty body.
+ */
+async function walkSitemap(url: string): Promise<SitemapEntry[]> {
+  const body = await fetchSitemapBody(url);
+  if (!body) return [];
+
+  // fast-xml-parser leaves single-child elements as objects, multi-child as
+  // arrays — `arr()` normalizes that ambiguity.
+  const parser = new XMLParser({ ignoreAttributes: true });
+  const parsed = parser.parse(body) as {
+    sitemapindex?: {
+      sitemap?: { loc: string } | { loc: string }[];
+    };
+    urlset?: {
+      url?:
+        | { loc: string; lastmod?: string }
+        | { loc: string; lastmod?: string }[];
+    };
+  };
+
+  if (parsed.sitemapindex) {
+    const entries = arr(parsed.sitemapindex.sitemap);
+    const nested = await Promise.all(entries.map((e) => walkSitemap(e.loc)));
+    return nested.flat();
+  }
+
+  if (parsed.urlset) {
+    return arr(parsed.urlset.url).map((u) => ({
+      loc: u.loc,
+      lastmod: u.lastmod,
+    }));
+  }
+
+  return [];
+}
+
+async function fetchSitemapBody(url: string): Promise<string | null> {
+  const res = await fetch(url, {
+    headers: { "User-Agent": "TinyTripperBot/1.0 (+change-tracking)" },
+  });
+  if (!res.ok) {
+    throw new Error(`sitemap fetch failed: ${url} → HTTP ${res.status}`);
+  }
+
+  const isGz =
+    url.endsWith(".gz") ||
+    res.headers.get("content-type")?.includes("gzip") === true;
+
+  if (isGz) {
+    const buf = Buffer.from(await res.arrayBuffer());
+    if (buf.length === 0) {
+      // e.g. whatson.melbourne.vic.gov.au — 200 OK but empty body.
+      console.warn(`sitemap ${url} returned empty body, skipping`);
+      return null;
+    }
+    return gunzipSync(buf).toString("utf8");
+  }
+
+  return await res.text();
+}
+
+function arr<T>(x: T | T[] | undefined): T[] {
+  if (x == null) return [];
+  return Array.isArray(x) ? x : [x];
+}

--- a/convex/crons.ts
+++ b/convex/crons.ts
@@ -1,0 +1,15 @@
+import { cronJobs } from "convex/server";
+import { internal } from "./_generated/api";
+
+const crons = cronJobs();
+
+// Tier 1 of the scraping change-tracking pipeline. Every hour, look at all
+// active `scrapingSources` rows whose interval has elapsed and run their
+// detector. See docs/change-tracking.md.
+crons.interval(
+  "scrape-source-tick",
+  { hours: 1 },
+  internal.changeTracking.tick,
+);
+
+export default crons;

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -27,6 +27,25 @@ export const workflowConfig = {
   useMockScrape: v.optional(v.boolean()),
 };
 
+// How a scraping source discovers new URLs (Tier 1). See docs/change-tracking.md.
+export const scrapingSourceDetector = v.union(
+  v.object({
+    kind: v.literal("sitemap"),
+    sitemapUrl: v.string(),
+    pathIncludes: v.optional(v.string()), // e.g. "/melbourne/kids/"
+    pathExcludes: v.optional(v.array(v.string())), // e.g. ["/tag/", "/author/"]
+  }),
+  v.object({
+    kind: v.literal("rss"),
+    feedUrl: v.string(),
+  }),
+  v.object({
+    kind: v.literal("firecrawl-change"),
+    listingUrl: v.string(),
+    schemaJson: v.string(), // serialized JSON Schema for items
+  }),
+);
+
 export default defineSchema({
   activities: defineTable({
     name: v.string(),
@@ -156,14 +175,13 @@ export default defineSchema({
     .index("by_userId", ["userId"])
     .index("by_userId_and_activityId", ["userId", "activityId"]),
 
+  // A configured source we periodically check for new content. The detector
+  // decides *how* to discover new URLs; the detailScrapeOptions get passed to
+  // `startSingleScrape` once a new URL is found. See docs/change-tracking.md.
   scrapingSources: defineTable({
-    url: v.string(),
+    url: v.string(), // listing URL — display only
     name: v.optional(v.string()),
-    type: v.union(
-      v.literal("website"),
-      v.literal("social_media"),
-      v.literal("other"),
-    ),
+    active: v.optional(v.boolean()),
     interval: v.union(
       v.literal("daily"),
       v.literal("weekly"),
@@ -172,17 +190,29 @@ export default defineSchema({
     ),
     on: v.optional(v.number()), // 0 monday, 1 tuesday, ..., 6 sunday OR 0 january, 1 february, ..., 11 december
     createdAt: v.number(),
-    active: v.optional(v.boolean()),
     lastCheckedAt: v.optional(v.number()),
     lastChangeAt: v.optional(v.number()),
-    lastChangePreviousScrapeAt: v.optional(v.string()),
-    scrapeConfig: v.optional(
-      v.object({
-        ...scrapeOptions,
-        urgencyDefault: v.optional(
-          v.union(v.literal("low"), v.literal("medium"), v.literal("high")),
-        ),
-      }),
-    ),
+    detector: scrapingSourceDetector,
+    detailScrapeOptions: v.optional(v.object(scrapeOptions)),
   }).index("by_active_lastCheckedAt", ["active", "lastCheckedAt"]),
+
+  // One row per URL discovered by a detector. Doubles as audit log and as the
+  // "seen set" the detector diffs against on the next tick.
+  scrapingSourceItems: defineTable({
+    sourceId: v.id("scrapingSources"),
+    url: v.string(),
+    lastmod: v.optional(v.string()), // sitemap <lastmod> or RSS pubDate, if any
+    contentHash: v.optional(v.string()), // for diff-based detectors
+    firstSeenAt: v.number(),
+    lastSeenAt: v.number(),
+    status: v.union(
+      v.literal("discovered"), // detected, not yet queued
+      v.literal("queued"), // Tier 2 workflow scheduled
+      v.literal("scraped"), // Tier 2 finished
+      v.literal("failed"),
+    ),
+    detailWorkflowId: v.optional(v.string()),
+  })
+    .index("by_source_and_url", ["sourceId", "url"])
+    .index("by_source_and_status", ["sourceId", "status"]),
 });

--- a/convex/scrapeWorkflow.ts
+++ b/convex/scrapeWorkflow.ts
@@ -385,6 +385,14 @@ export const startSingleScrape = mutation({
     scraper: v.optional(scrapeOptions.scraper),
     tagsHint: v.optional(scrapeOptions.tagsHint),
     workflowConfig: v.optional(v.object(workflowConfig)),
+    // When this scrape was triggered by change tracking, the originating
+    // source item — so completion can flip its status. See changeTracking.ts.
+    source: v.optional(
+      v.object({
+        sourceId: v.id("scrapingSources"),
+        url: v.string(),
+      }),
+    ),
   },
   handler: async (ctx, args): Promise<string> => {
     const workflowId: string = await workflow.start(
@@ -404,7 +412,10 @@ export const startSingleScrape = mutation({
       },
       {
         onComplete: internal.scrapeWorkflow.handleWorkflowComplete,
-        context: { autoImport: args.workflowConfig?.autoImport ?? false },
+        context: {
+          autoImport: args.workflowConfig?.autoImport ?? false,
+          source: args.source,
+        },
       },
     );
 
@@ -427,7 +438,22 @@ export const handleWorkflowComplete = internalMutation({
     );
 
     // Extract our context
-    const context = args.context as { autoImport: boolean };
+    const context = args.context as {
+      autoImport: boolean;
+      source?: { sourceId: Id<"scrapingSources">; url: string };
+    };
+
+    // Change-tracking writeback: flip the originating source item's status so
+    // the audit log reflects the outcome of the detail scrape.
+    if (context.source) {
+      const status =
+        args.result.kind === "success" ? "scraped" : ("failed" as const);
+      await ctx.scheduler.runAfter(0, internal.scrapingSourceItems.setStatus, {
+        sourceId: context.source.sourceId,
+        url: context.source.url,
+        status,
+      });
+    }
 
     if (args.result.kind === "success") {
       // If autoImport is true and workflow succeeded, clean up storage files

--- a/convex/scrapingSourceItems.ts
+++ b/convex/scrapingSourceItems.ts
@@ -1,0 +1,123 @@
+import { v } from "convex/values";
+import { internalQuery, internalMutation } from "./_generated/server";
+
+const itemStatus = v.union(
+  v.literal("discovered"),
+  v.literal("queued"),
+  v.literal("scraped"),
+  v.literal("failed"),
+);
+
+/**
+ * All items previously discovered for this source. Detectors use this as the
+ * "seen set" — anything not in here is new, anything with a changed `lastmod`
+ * is updated.
+ */
+export const listBySource = internalQuery({
+  args: { sourceId: v.id("scrapingSources") },
+  returns: v.array(v.any()),
+  handler: async (ctx, { sourceId }) => {
+    return await ctx.db
+      .query("scrapingSourceItems")
+      .withIndex("by_source_and_url", (q) => q.eq("sourceId", sourceId))
+      .collect();
+  },
+});
+
+/**
+ * Upsert a batch of items by (sourceId, url). Inserts new rows with status
+ * `discovered`; for existing rows, updates `lastSeenAt` / `lastmod` /
+ * `contentHash`. Status is left alone on update — the caller (or the Tier 2
+ * dispatcher) is responsible for moving rows to `queued`/`scraped`/`failed`.
+ */
+export const upsertBatch = internalMutation({
+  args: {
+    sourceId: v.id("scrapingSources"),
+    items: v.array(
+      v.object({
+        url: v.string(),
+        lastmod: v.optional(v.string()),
+        contentHash: v.optional(v.string()),
+      }),
+    ),
+    now: v.number(),
+  },
+  returns: v.null(),
+  handler: async (ctx, { sourceId, items, now }) => {
+    for (const item of items) {
+      const existing = await ctx.db
+        .query("scrapingSourceItems")
+        .withIndex("by_source_and_url", (q) =>
+          q.eq("sourceId", sourceId).eq("url", item.url),
+        )
+        .unique();
+
+      if (existing) {
+        await ctx.db.patch(existing._id, {
+          lastSeenAt: now,
+          lastmod: item.lastmod ?? existing.lastmod,
+          contentHash: item.contentHash ?? existing.contentHash,
+        });
+      } else {
+        await ctx.db.insert("scrapingSourceItems", {
+          sourceId,
+          url: item.url,
+          lastmod: item.lastmod,
+          contentHash: item.contentHash,
+          firstSeenAt: now,
+          lastSeenAt: now,
+          status: "discovered",
+        });
+      }
+    }
+    return null;
+  },
+});
+
+/**
+ * Mark an item as queued for detail scrape and record the workflow id.
+ * Called after Tier 2 dispatch so we don't re-queue the same URL next tick.
+ */
+export const markQueued = internalMutation({
+  args: {
+    sourceId: v.id("scrapingSources"),
+    url: v.string(),
+    detailWorkflowId: v.string(),
+  },
+  returns: v.null(),
+  handler: async (ctx, { sourceId, url, detailWorkflowId }) => {
+    const existing = await ctx.db
+      .query("scrapingSourceItems")
+      .withIndex("by_source_and_url", (q) =>
+        q.eq("sourceId", sourceId).eq("url", url),
+      )
+      .unique();
+    if (!existing) return null;
+    await ctx.db.patch(existing._id, { status: "queued", detailWorkflowId });
+    return null;
+  },
+});
+
+/**
+ * Manual status transition — useful if a downstream workflow completion
+ * callback wants to flip discovered/queued rows to `scraped` or `failed`.
+ */
+export const setStatus = internalMutation({
+  args: {
+    sourceId: v.id("scrapingSources"),
+    url: v.string(),
+    status: itemStatus,
+  },
+  returns: v.null(),
+  handler: async (ctx, { sourceId, url, status }) => {
+    const existing = await ctx.db
+      .query("scrapingSourceItems")
+      .withIndex("by_source_and_url", (q) =>
+        q.eq("sourceId", sourceId).eq("url", url),
+      )
+      .unique();
+    if (!existing) return null;
+    await ctx.db.patch(existing._id, { status });
+    return null;
+  },
+});

--- a/convex/scrapingSources.ts
+++ b/convex/scrapingSources.ts
@@ -1,0 +1,149 @@
+import { v } from "convex/values";
+import {
+  internalQuery,
+  internalMutation,
+  mutation,
+  query,
+} from "./_generated/server";
+import { internal } from "./_generated/api";
+import { scrapeOptions, scrapingSourceDetector } from "./schema";
+import type { Doc } from "./_generated/dataModel";
+
+/**
+ * Interval in milliseconds for each scheduling cadence. Used by `listDue`
+ * to decide whether a source is ready for another check.
+ */
+const INTERVAL_MS: Record<Doc<"scrapingSources">["interval"], number | null> = {
+  daily: 24 * 60 * 60 * 1000,
+  weekly: 7 * 24 * 60 * 60 * 1000,
+  monthly: 30 * 24 * 60 * 60 * 1000, // approximate — good enough for cron tick
+  manual: null, // never auto-due
+};
+
+// -------------------------------------------------------------------------
+// Public API — register and manage sources from the app
+// -------------------------------------------------------------------------
+
+export const list = query({
+  args: {},
+  returns: v.array(v.any()),
+  handler: async (ctx) => {
+    const identity = await ctx.auth.getUserIdentity();
+    if (!identity) throw new Error("Not authenticated");
+    return await ctx.db.query("scrapingSources").collect();
+  },
+});
+
+export const register = mutation({
+  args: {
+    url: v.string(),
+    name: v.optional(v.string()),
+    interval: v.union(
+      v.literal("daily"),
+      v.literal("weekly"),
+      v.literal("monthly"),
+      v.literal("manual"),
+    ),
+    detector: scrapingSourceDetector,
+    detailScrapeOptions: v.optional(v.object(scrapeOptions)),
+    active: v.optional(v.boolean()),
+  },
+  returns: v.id("scrapingSources"),
+  handler: async (ctx, args) => {
+    const identity = await ctx.auth.getUserIdentity();
+    if (!identity) throw new Error("Not authenticated");
+
+    return await ctx.db.insert("scrapingSources", {
+      url: args.url,
+      name: args.name,
+      interval: args.interval,
+      detector: args.detector,
+      detailScrapeOptions: args.detailScrapeOptions,
+      active: args.active ?? true,
+      createdAt: Date.now(),
+    });
+  },
+});
+
+export const setActive = mutation({
+  args: { sourceId: v.id("scrapingSources"), active: v.boolean() },
+  returns: v.null(),
+  handler: async (ctx, { sourceId, active }) => {
+    const identity = await ctx.auth.getUserIdentity();
+    if (!identity) throw new Error("Not authenticated");
+    await ctx.db.patch(sourceId, { active });
+    return null;
+  },
+});
+
+/**
+ * Manually trigger a detection run now, bypassing the interval schedule.
+ * Useful for `interval: "manual"` sources and for testing.
+ */
+export const runNow = mutation({
+  args: { sourceId: v.id("scrapingSources") },
+  returns: v.null(),
+  handler: async (ctx, { sourceId }) => {
+    const identity = await ctx.auth.getUserIdentity();
+    if (!identity) throw new Error("Not authenticated");
+    await ctx.scheduler.runAfter(0, internal.changeTracking.detectChanges, {
+      sourceId,
+    });
+    return null;
+  },
+});
+
+// -------------------------------------------------------------------------
+// Internal API — used by the change-tracking pipeline
+// -------------------------------------------------------------------------
+
+export const get = internalQuery({
+  args: { sourceId: v.id("scrapingSources") },
+  returns: v.union(v.any(), v.null()),
+  handler: async (ctx, { sourceId }) => {
+    return await ctx.db.get(sourceId);
+  },
+});
+
+/**
+ * Active sources whose `lastCheckedAt + interval` is in the past.
+ * Excludes `interval: "manual"` rows — those run only via explicit trigger.
+ */
+export const listDue = internalQuery({
+  args: { now: v.number() },
+  returns: v.array(v.any()),
+  handler: async (ctx, { now }) => {
+    const active = await ctx.db
+      .query("scrapingSources")
+      .withIndex("by_active_lastCheckedAt", (q) => q.eq("active", true))
+      .collect();
+
+    return active.filter((s) => {
+      const intervalMs = INTERVAL_MS[s.interval];
+      if (intervalMs == null) return false;
+      const lastChecked = s.lastCheckedAt ?? 0;
+      return lastChecked + intervalMs <= now;
+    });
+  },
+});
+
+/**
+ * Update bookkeeping after a detection run. Always bumps `lastCheckedAt`;
+ * bumps `lastChangeAt` only when the detector actually found changes.
+ */
+export const markChecked = internalMutation({
+  args: {
+    sourceId: v.id("scrapingSources"),
+    checkedAt: v.number(),
+    changed: v.boolean(),
+  },
+  returns: v.null(),
+  handler: async (ctx, { sourceId, checkedAt, changed }) => {
+    const patch: Partial<Doc<"scrapingSources">> = {
+      lastCheckedAt: checkedAt,
+    };
+    if (changed) patch.lastChangeAt = checkedAt;
+    await ctx.db.patch(sourceId, patch);
+    return null;
+  },
+});

--- a/docs/adr/0001-change-tracking-two-tier-detection.md
+++ b/docs/adr/0001-change-tracking-two-tier-detection.md
@@ -1,0 +1,66 @@
+# ADR 0001 — Change tracking: two-tier orchestration with pluggable detectors
+
+- **Status**: Accepted
+- **Date**: 2026-05-07
+
+## Context
+
+We need to keep `activities` fresh as our scraping sources (`mammaknowsmelbourne.com.au`, `timeout.com/melbourne/kids`, `whatson.melbourne.vic.gov.au`, etc.) publish new content. The existing `websiteScrapeWorkflow` does a deep crawl — extract → geocode → embed → import — which is expensive and not appropriate to run on a schedule against every source just to discover whether anything is new.
+
+Constraints we audited up-front:
+
+- The three target sources don't all expose the same metadata. We probed each:
+  - mamma — `sitemap.xml` with per-URL `<lastmod>`; no RSS.
+  - timeout — sitemap-index of 14 shards, per-URL `<lastmod>`, `/kids` paths sprinkled across shards; no RSS link tags; the advertised `news_sitemap.xml` is Google-News-spec (last 48h only) and too narrow.
+  - whatson — `sitemap.xml.gz` returns 200 with `content-length: 0`; `/sitemap.xml` and `/sitemap_index.xml` 404; no feed link tags.
+- A single detection mechanism would force us to either (a) re-crawl every site every tick (wasteful) or (b) only support the lowest common denominator (whatever whatson allows, i.e. firecrawl).
+- The full scrape workflow already exists and works; we want change tracking to *feed it*, not replace it.
+
+## Decision
+
+**Two-tier orchestration** with **pluggable per-source detectors**:
+
+1. **Tier 1 — index check** (cheap, hourly cron). For each due source, the configured detector returns the set of URLs that are new or updated since last check. Detector kinds:
+   - `sitemap` — fetch and recursively walk a sitemap (handles `<sitemapindex>` and `.gz`); optional `pathIncludes` / `pathExcludes` filter; diff by URL + `<lastmod>`.
+   - `rss` — parse an RSS/Atom feed; diff by `pubDate`. *(stub)*
+   - `firecrawl-change` — Firecrawl's `changeTracking` feature in `json` mode against a schema describing items on the listing page; diff returned by Firecrawl. *(stub)*
+2. **Tier 2 — detail scrape** (expensive, on hits). For each new/updated URL, schedule `startSingleScrape` (the existing `websiteScrapeWorkflow` with `maxCrawlVisit=1, maxDepth=0`).
+
+The detector kind is a Convex discriminated union on the `scrapingSources` row. Per-URL state lives in a sibling `scrapingSourceItems` table (`by_source_and_url` index), serving as both the audit log and the "seen set" the detector diffs against.
+
+Detection priority when onboarding a new source: RSS → sitemap → firecrawl-change. Codified in `docs/change-tracking.md`.
+
+## Alternatives considered
+
+- **Single mechanism: firecrawl change tracking on every source.** Rejected. Charges a scrape credit per check per source. Ties Tier 1 to one vendor. Wastes the free, reliable per-URL `<lastmod>` signal sites already publish.
+- **Single mechanism: whole-page hash-and-diff via cron.** Rejected. Tells us *something* changed but not *what*; we'd still have to crawl the listing to find the new article URL. Strictly worse than parsing the URL list ourselves.
+- **CSS-selector scraper per site for Tier 1.** Rejected as the default. More flexible than any of the above, but maintenance cost is high — selectors break on redesigns. Reserve as a last-resort detector we add only if RSS/sitemap/firecrawl all fail.
+- **`type` taxonomy on `scrapingSources` (`website`/`social_media`/`other`).** Dropped from the original schema scaffold. The `detector.kind` already discriminates by *how* to detect; the source type is at best display metadata and adds no behavior.
+- **Inline `seenUrls` array on the source row.** Rejected. Timeout's full sitemap is ~14k URLs — would bloat the source document past sensible size. Sibling `scrapingSourceItems` table scales and gives us per-URL audit trail for free.
+- **Triggering the full `websiteScrapeWorkflow` per new URL.** Considered but unnecessary — `startSingleScrape` already exists and is the right entry point. We pass through `scraper` and `tagsHint` from `detailScrapeOptions` on the source row.
+
+## Consequences
+
+**Positive**
+
+- Cheap detection: an hourly cron against mamma is one HTTP fetch + a small XML parse; against timeout it's 14 small gzipped fetches (CloudFront-cached). Detail scrape only runs on actual hits.
+- Adding a new source is a config-only change once a detector kind covers it. The `docs/change-tracking.md` checklist makes the per-site decision deterministic.
+- `scrapingSourceItems` doubles as a provenance log — every imported `activity.sourceUrl` ties back to the row that discovered it and the workflow that scraped it.
+- The detector union is open for extension. A future `css-selector` or `json-api` detector slots into the existing dispatcher without changing the tier model.
+
+**Negative / accepted trade-offs**
+
+- `firecrawl-change` detects only genuinely new URLs, not content updates to an already-seen URL (Firecrawl items carry no per-item `lastmod`). Acceptable: for a listing page, "new entry" is the signal we care about.
+- The `rss` detector is implemented but not yet exercised against a live source — none of our three current sources expose a usable feed.
+- New runtime dependency: `fast-xml-parser` (small, no transitives).
+- `changeTracking.ts` runs in Node (`"use node"`) because `zlib.gunzipSync` isn't available in the V8 isolate.
+- Sitemap detection depends on sites maintaining accurate `<lastmod>` values. If a site bumps `lastmod` on every nightly republish, we'd re-scrape unchanged content. Mitigation deferred — we'll watch detail-scrape volume and add a content-hash check if it becomes an issue.
+- Sources with `interval: "manual"` never auto-tick; they're triggered out-of-band. By design, but worth being explicit about.
+
+## Implementation references
+
+- Schema: [`convex/schema.ts`](../../convex/schema.ts) — `scrapingSources` (with `detector` union) + `scrapingSourceItems`.
+- Tier 1: [`convex/changeTracking.ts`](../../convex/changeTracking.ts) — `tick`, `detectChanges`, sitemap walker.
+- Tier 2 entry: `convex/scrapeWorkflow.ts` → `startSingleScrape`.
+- Cron: [`convex/crons.ts`](../../convex/crons.ts) — hourly tick.
+- Onboarding checklist: [`docs/change-tracking.md`](../change-tracking.md).

--- a/docs/change-tracking.md
+++ b/docs/change-tracking.md
@@ -1,0 +1,191 @@
+# Change Tracking for Scraping Sources
+
+How we detect new content on listing pages (e.g. "the latest activities on site X") and feed only the changed URLs into the heavy scrape pipeline.
+
+## Two-tier model
+
+The pipeline splits cleanly into:
+
+- **Tier 1 — index check** (cheap, runs on a cron). For one configured *source*, returns the set of URLs that are new or updated since last check.
+- **Tier 2 — detail scrape** (expensive, runs only on Tier 1 hits). For each URL, kicks off the existing `websiteScrapeWorkflow` with `maxCrawlVisit=1, maxDepth=0`.
+
+This split is the backbone. The Tier 1 detection mechanism is **pluggable per source** because real-world sites don't all expose the same metadata.
+
+```mermaid
+flowchart TD
+    Cron[/cron tick/] --> Due[list sources where<br/>now - lastCheckedAt > interval]
+    Due --> Detect[detectChanges]
+    Detect --> Kind{detector.kind}
+    Kind -- sitemap --> SitemapDet[walk sitemap<br/>filter by path<br/>diff vs scrapingSourceItems]
+    Kind -- rss --> RssDet[parse feed<br/>diff vs scrapingSourceItems]
+    Kind -- firecrawl-change --> FcDet[firecrawl JSON change tracking<br/>on listing page]
+    SitemapDet --> Upsert[upsert scrapingSourceItems]
+    RssDet --> Upsert
+    FcDet --> Upsert
+    Upsert --> Dispatch[for each new/updated URL:<br/>schedule startSingleArticleScrape]
+    Dispatch --> Tier2[[websiteScrapeWorkflow<br/>maxCrawlVisit=1, maxDepth=0]]
+```
+
+## Detector taxonomy
+
+| Detector | When to use | State per item | Notes |
+|---|---|---|---|
+| `sitemap` | Site has a working `sitemap.xml` (or `.xml.gz`) covering the URLs you care about | `lastmod` from `<lastmod>` | Walks `<sitemapindex>` recursively. Path filter (`pathIncludes`) lets you target a sub-section like `/melbourne/kids/` inside a much larger sitemap. |
+| `rss` | Site exposes an RSS/Atom feed listing the items you want | `pubDate` | Cheapest. Bounded item count (most feeds cap at ~10–50 most recent). |
+| `firecrawl-change` | No feed and no usable sitemap | content hash kept by firecrawl | Uses [Firecrawl change tracking](https://docs.firecrawl.dev/features/change-tracking) in `json` mode against a schema like `{ items: [{ url, title }] }`. Most expensive (one scrape credit per check) and ties Tier 1 to firecrawl. |
+
+## Adding a new source — checklist
+
+When someone gives you a new URL to track, walk these checks in order. Stop at the first one that gives you a usable signal.
+
+### 1. RSS / Atom feed
+
+```bash
+# look for a feed link in the page <head>
+curl -sSL -H "User-Agent: Mozilla/5.0" "$URL" \
+  | grep -iE 'rel="alternate"|application/rss|application/atom'
+
+# common conventions to probe
+curl -sSI "$ORIGIN/feed/"            # WordPress
+curl -sSI "$ORIGIN/rss"
+curl -sSI "$URL/feed"
+curl -sSI "$URL?format=rss"          # Squarespace
+```
+
+A working feed returns 200 with `content-type: application/rss+xml` (or `application/atom+xml`) and well-formed XML with `<item>` / `<entry>` elements. **Verify it covers the items you care about** — some feeds only expose news posts and skip evergreen pages.
+
+### 2. Sitemap
+
+```bash
+# robots.txt is the canonical pointer
+curl -sSL "$ORIGIN/robots.txt" | grep -i sitemap
+
+# common conventions to probe
+curl -sSI "$ORIGIN/sitemap.xml"
+curl -sSI "$ORIGIN/sitemap.xml.gz"
+curl -sSI "$ORIGIN/sitemap_index.xml"
+```
+
+A working sitemap means: HTTP 200, **`content-length > 0`**, body parses as XML with `<urlset>` (or `<sitemapindex>` pointing at child sitemaps).
+
+Critical follow-up checks:
+
+- **Is it empty?** Some servers respond 200 with `content-length: 0` on the gzipped path (we've seen this on `whatson.melbourne.vic.gov.au`). That's not a usable sitemap.
+- **Does it have `<lastmod>`?** Without it you can detect *new* URLs but not *updated* ones — usually fine for our use case but worth noting.
+- **Does it cover your URLs?** Big multi-region sites (e.g. `timeout.com`) have a sitemap-index pointing at sharded sitemaps. The high-level `news_sitemap.xml` is usually too narrow (Google News spec — last 48h only). The full city sitemap is the real target. Filter URLs by path to your section.
+
+### 3. Firecrawl change tracking (fallback)
+
+If the first two yield nothing, configure a `firecrawl-change` detector against the listing page. Define a JSON schema describing the items you care about:
+
+```json
+{ "items": [{ "url": "string", "title": "string" }] }
+```
+
+Firecrawl returns `{ status: "new" | "same" | "changed" | "removed", json: { previous, current } }` on each scrape — diff `current.items[].url` against `previous.items[].url` to get the new ones.
+
+### Decision tree
+
+```mermaid
+flowchart TD
+    Start([new source URL]) --> RSS{RSS/Atom found?}
+    RSS -- yes --> CoverageA{covers the items<br/>you care about?}
+    CoverageA -- yes --> UseRss[detector: rss]
+    CoverageA -- no --> Sitemap
+    RSS -- no --> Sitemap{sitemap found<br/>and non-empty?}
+    Sitemap -- yes --> Lastmod{has &lt;lastmod&gt;<br/>per URL?}
+    Lastmod -- yes --> CoverageB{covers your URLs?<br/>(may need path filter)}
+    Lastmod -- no --> CoverageB
+    CoverageB -- yes --> UseSitemap[detector: sitemap<br/>with pathIncludes]
+    CoverageB -- no --> Firecrawl
+    Sitemap -- no --> Firecrawl[detector: firecrawl-change]
+```
+
+## Audit: the three sources we evaluated
+
+Probed 2026-05-06.
+
+| Source | RSS | Sitemap | Chosen detector |
+|---|---|---|---|
+| `mammaknowsmelbourne.com.au/the-latest` | ❌ `/feed/`, `?format=rss`, `/the-latest/feed` all error | ✅ `sitemap.xml` is a single urlset, ~80+ URLs, per-URL `<lastmod>`. Lists individual content URLs (playgrounds, dining), not the `/the-latest` aggregation — which is actually better, we don't depend on listing-page DOM | `sitemap` |
+| `timeout.com/melbourne/kids` | ❌ no feed link tags | ✅ `/melbourne/sitemap.xml.gz` is an index of 14 shards × ~1000 URLs each, per-URL `<lastmod>`. `/melbourne/kids/*` paths are sprinkled across shards, ~50–100 total. The advertised `news_sitemap.xml` is too narrow (Google News spec, last 48h only). | `sitemap` with `pathIncludes: "/melbourne/kids/"` |
+| `whatson.melbourne.vic.gov.au/things-to-do/family-and-kids` | ❌ no feed link tags | ❌ `/sitemap.xml.gz` returns 200 OK with `content-length: 0`; `/sitemap.xml` and `/sitemap_index.xml` return 404 | `firecrawl-change` |
+
+## Schema
+
+```ts
+// convex/schema.ts
+
+scrapingSources: defineTable({
+  url: v.string(),                  // listing URL (display)
+  name: v.optional(v.string()),
+  active: v.optional(v.boolean()),
+  interval: v.union(
+    v.literal("daily"), v.literal("weekly"),
+    v.literal("monthly"), v.literal("manual"),
+  ),
+  lastCheckedAt: v.optional(v.number()),
+  lastChangeAt: v.optional(v.number()),
+  detector: v.union(
+    v.object({
+      kind: v.literal("sitemap"),
+      sitemapUrl: v.string(),
+      pathIncludes: v.optional(v.string()),
+      pathExcludes: v.optional(v.array(v.string())),
+    }),
+    v.object({
+      kind: v.literal("rss"),
+      feedUrl: v.string(),
+    }),
+    v.object({
+      kind: v.literal("firecrawl-change"),
+      listingUrl: v.string(),
+      schemaJson: v.string(),
+    }),
+  ),
+  detailScrapeOptions: v.optional(v.object(scrapeOptions)),
+  createdAt: v.number(),
+}).index("by_active_lastCheckedAt", ["active", "lastCheckedAt"]),
+
+scrapingSourceItems: defineTable({
+  sourceId: v.id("scrapingSources"),
+  url: v.string(),
+  lastmod: v.optional(v.string()),
+  contentHash: v.optional(v.string()),
+  firstSeenAt: v.number(),
+  lastSeenAt: v.number(),
+  status: v.union(
+    v.literal("discovered"),
+    v.literal("queued"),
+    v.literal("scraped"),
+    v.literal("failed"),
+  ),
+  detailWorkflowId: v.optional(v.string()),
+})
+  .index("by_source_and_url", ["sourceId", "url"])
+  .index("by_source_and_status", ["sourceId", "status"]),
+```
+
+## Key entry points
+
+- `convex/crons.ts` — hourly `scrape-source-tick`.
+- `convex/changeTracking.ts` (`"use node"`) — `tick`, `detectChanges` dispatcher, and all three detectors (`detectViaSitemap`, `detectViaRss`, `detectViaFirecrawl`). Sitemap walker handles gzip + sitemap-index recursion.
+- `convex/scrapingSources.ts` — public `register` / `list` / `setActive` / `runNow`; internal `get` / `listDue` / `markChecked`.
+- `convex/scrapingSourceItems.ts` — internal `listBySource` / `upsertBatch` / `markQueued` / `setStatus`.
+- `convex/scrapeWorkflow.ts` → `startSingleScrape` — Tier 2 entry, wraps `websiteScrapeWorkflow` with `maxCrawlVisit=1, maxDepth=0`. Accepts an optional `source: { sourceId, url }` so `handleWorkflowComplete` can flip the item's status to `scraped`/`failed`.
+
+## Lifecycle of a source item
+
+`discovered` (detector found it) → `queued` (Tier 2 workflow scheduled, `detailWorkflowId` set) → `scraped` / `failed` (workflow completed, written back by `handleWorkflowComplete`).
+
+## Status of the detectors
+
+- `sitemap` — implemented, smoke-tested against mamma.
+- `rss` — implemented (RSS 2.0 + Atom), not yet exercised against a live source.
+- `firecrawl-change` — implemented. Diffs Firecrawl's `changeTracking.json.items.current` against our own seen set. No per-item `lastmod`, so it only detects genuinely new URLs, not content updates to an already-seen URL.
+
+## New dependencies
+
+- `fast-xml-parser` — sitemap/RSS parsing. Small, no transitives.
+- `@mendable/firecrawl-js` — already a dependency (used by the main scrape pipeline); reused for the `firecrawl-change` detector.
+- `zlib` — built-in (Node), used for `.gz` sitemaps.

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@t3-oss/env-core": "^0.13.10",
     "@t3-oss/env-nextjs": "^0.13.10",
     "convex": "^1.31.7",
+    "fast-xml-parser": "^5.8.0",
     "jiti": "^2.6.1",
     "lucide-react": "^0.542.0",
     "next": "15.2.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,6 +47,9 @@ importers:
       convex:
         specifier: ^1.31.7
         version: 1.31.7(@clerk/clerk-react@5.60.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
+      fast-xml-parser:
+        specifier: ^5.8.0
+        version: 5.8.0
       jiti:
         specifier: ^2.6.1
         version: 2.6.1
@@ -922,6 +925,9 @@ packages:
   '@noble/hashes@1.8.0':
     resolution: {integrity: sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==}
     engines: {node: ^14.21.3 || >=16}
+
+  '@nodable/entities@2.1.0':
+    resolution: {integrity: sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==}
 
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -2609,6 +2615,13 @@ packages:
   fast-sha256@1.3.0:
     resolution: {integrity: sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==}
 
+  fast-xml-builder@1.2.0:
+    resolution: {integrity: sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==}
+
+  fast-xml-parser@5.8.0:
+    resolution: {integrity: sha512-6bIM7fsJxeo3uXv7OncQYsBAMPJ7V16Slahl/6M98C/i2q+vB1+4a0MtrvYwDFEUrwDSbAmeLDRXsOBwrL7yAg==}
+    hasBin: true
+
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
 
@@ -3240,6 +3253,10 @@ packages:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
 
+  path-expression-matcher@1.5.0:
+    resolution: {integrity: sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==}
+    engines: {node: '>=14.0.0'}
+
   path-key@2.0.1:
     resolution: {integrity: sha512-fEHGKCSmUSDPv4uoj8AlD+joPlq3peND+HRYyxFz4KPw4z926S/b8rIuFs2FYJg3BwsxJf6A9/3eIdLaYC+9Dw==}
     engines: {node: '>=4'}
@@ -3587,6 +3604,9 @@ packages:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
 
+  strnum@2.3.0:
+    resolution: {integrity: sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==}
+
   styled-jsx@5.1.6:
     resolution: {integrity: sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA==}
     engines: {node: '>= 12.0.0'}
@@ -3763,6 +3783,10 @@ packages:
   word-wrap@1.2.5:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
+
+  xml-naming@0.1.0:
+    resolution: {integrity: sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==}
+    engines: {node: '>=16.0.0'}
 
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
@@ -4356,6 +4380,8 @@ snapshots:
       '@noble/hashes': 1.8.0
 
   '@noble/hashes@1.8.0': {}
+
+  '@nodable/entities@2.1.0': {}
 
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
@@ -6247,6 +6273,19 @@ snapshots:
 
   fast-sha256@1.3.0: {}
 
+  fast-xml-builder@1.2.0:
+    dependencies:
+      path-expression-matcher: 1.5.0
+      xml-naming: 0.1.0
+
+  fast-xml-parser@5.8.0:
+    dependencies:
+      '@nodable/entities': 2.1.0
+      fast-xml-builder: 1.2.0
+      path-expression-matcher: 1.5.0
+      strnum: 2.3.0
+      xml-naming: 0.1.0
+
   fastq@1.20.1:
     dependencies:
       reusify: 1.1.0
@@ -6841,6 +6880,8 @@ snapshots:
 
   path-exists@4.0.0: {}
 
+  path-expression-matcher@1.5.0: {}
+
   path-key@2.0.1: {}
 
   path-key@3.1.1: {}
@@ -7334,6 +7375,8 @@ snapshots:
 
   strip-json-comments@3.1.1: {}
 
+  strnum@2.3.0: {}
+
   styled-jsx@5.1.6(react@19.2.4):
     dependencies:
       client-only: 0.0.1
@@ -7557,6 +7600,8 @@ snapshots:
       isexe: 3.1.2
 
   word-wrap@1.2.5: {}
+
+  xml-naming@0.1.0: {}
 
   yocto-queue@0.1.0: {}
 


### PR DESCRIPTION
## What

Adds a **two-tier change-tracking pipeline** so we can keep `activities` fresh without re-crawling whole sites. An hourly cron checks each active scraping source with a **pluggable detector**, and schedules a single-URL detail scrape for each new/updated URL it finds.

- **Tier 1 — index check** (cheap, hourly cron): per-source detector returns new/updated URLs.
- **Tier 2 — detail scrape** (expensive, on hits): reuses the existing `websiteScrapeWorkflow` via `startSingleScrape` (`maxCrawlVisit=1, maxDepth=0`).

## Detectors

| kind | use when | status |
|---|---|---|
| `sitemap` | site has a working sitemap (`.xml`/`.xml.gz`, sitemap-index supported) | implemented, smoke-tested against mamma |
| `rss` | site exposes an RSS/Atom feed | implemented (RSS 2.0 + Atom), not yet exercised live |
| `firecrawl-change` | no feed/sitemap — fall back to Firecrawl change tracking | implemented; new-URL detection only |

## Changes

- **schema**: discriminated `detector` union on `scrapingSources` (drops old `type`/`scrapeConfig`); new `scrapingSourceItems` table doubling as audit log + seen set.
- **`changeTracking.ts`** (`"use node"`): `tick` + `detectChanges` dispatcher + all three detectors. Sitemap walker handles gzip + sitemap-index recursion and the whatson empty-body quirk.
- **`scrapeWorkflow.ts`**: `startSingleScrape` threads an optional `source` through workflow context so `handleWorkflowComplete` writes the item status back (`discovered → queued → scraped/failed`).
- **public API**: `register` / `list` / `setActive` / `runNow` (Clerk-auth-gated).
- **`crons.ts`**: hourly `scrape-source-tick`.
- **docs**: `docs/change-tracking.md` (model + new-source onboarding checklist) and `docs/adr/0001-*`.

## New deps

- `fast-xml-parser` (sitemap/RSS parsing). `@mendable/firecrawl-js` already present.

## Test plan

- [x] `tsc --noEmit` clean, `pnpm lint` clean (pre-existing `ImageUpload.tsx` warning only).
- [x] Sitemap detector smoke-tested end-to-end against mammaknowsmelbourne.
- [ ] RSS detector against a live feed (none of the 3 current sources expose one).
- [ ] firecrawl-change against whatson — note: first run records all current items as new.

🤖 Generated with [Claude Code](https://claude.com/claude-code)