### PR TITLE
feat: image-to-LLM form prefill on create activity page

### DIFF
--- a/app/tt/create/page.tsx
+++ b/app/tt/create/page.tsx
@@ -3,7 +3,7 @@
 import { useAction, useMutation } from "convex/react";
 import { api } from "@/convex/_generated/api";
 import { useForm } from "react-hook-form";
-import { useState, useRef } from "react";
+import { useState, useRef, type CSSProperties } from "react";
 import {
   Button,
   Flex,
@@ -22,7 +22,10 @@ import { Loader } from "@googlemaps/js-api-loader";
 import { env } from "@/env";
 import GooglePlacesAutocomplete from "@/components/GooglePlacesAutocomplete";
 import TagCombobox from "@/components/TagCombobox";
-import ImageUpload, { type ImageUploadHandle } from "@/components/ImageUpload";
+import ImageUpload, {
+  type ImageUploadHandle,
+  type ExtractedActivity,
+} from "@/components/ImageUpload";
 import { useRouter } from "next/navigation";
 import { ROUTES } from "@/app/routes";
 import type { Id } from "@/convex/_generated/dataModel";
@@ -144,6 +147,7 @@ export default function CreateActivityPage() {
     reset,
     watch,
     setValue,
+    getValues,
   } = useForm<ActivityFormData>({
     defaultValues: {
       isPublic: true,
@@ -158,6 +162,56 @@ export default function CreateActivityPage() {
   const inHome = watch("inHome");
   const tags = watch("tags") || [];
   const imageId = watch("imageId");
+
+  const hasSubmittedRef = useRef(false);
+  const [highlightFields, setHighlightFields] = useState<
+    Set<keyof ActivityFormData>
+  >(new Set());
+
+  const highlightStyle = (field: keyof ActivityFormData): CSSProperties =>
+    highlightFields.has(field)
+      ? {
+          transition: "background-color 0.4s ease",
+          backgroundColor: "var(--accent-a3)",
+          borderRadius: "var(--radius-2)",
+        }
+      : { transition: "background-color 0.4s ease" };
+
+  // Pre-fill empty/untouched form fields from the image-extraction result.
+  const handleExtracted = (extracted: ExtractedActivity) => {
+    // Drop results that arrive after the form was submitted / navigated away.
+    if (hasSubmittedRef.current) return;
+
+    const before = getValues();
+    const definedExtracted: Partial<ActivityFormData> = {};
+    if (extracted.name) definedExtracted.name = extracted.name;
+    if (extracted.description)
+      definedExtracted.description = extracted.description;
+    if (extracted.tags && extracted.tags.length > 0)
+      definedExtracted.tags = extracted.tags;
+    if (extracted.rainApproved !== null)
+      definedExtracted.rainApproved = extracted.rainApproved;
+    if (extracted.inHome !== null) definedExtracted.inHome = extracted.inHome;
+
+    // keepDirtyValues keeps every field the user has touched (dirty); spreading
+    // `before` preserves untouched non-extracted fields (imageId, isPublic, …).
+    reset({ ...before, ...definedExtracted }, { keepDirtyValues: true });
+
+    // Briefly highlight only the fields the merge actually changed.
+    const after = getValues();
+    const changed = new Set<keyof ActivityFormData>();
+    (
+      ["name", "description", "tags", "rainApproved", "inHome"] as const
+    ).forEach((field) => {
+      if (JSON.stringify(before[field]) !== JSON.stringify(after[field])) {
+        changed.add(field);
+      }
+    });
+    if (changed.size > 0) {
+      setHighlightFields(changed);
+      setTimeout(() => setHighlightFields(new Set()), 2000);
+    }
+  };
 
   const handleUseCurrentLocation = () => {
     setLocationError(null);
@@ -210,6 +264,7 @@ export default function CreateActivityPage() {
               },
               result.formatted_address,
             ),
+            { shouldDirty: true },
           );
         } catch (error) {
           otel.captureException(error, { context: "create_location_lookup" });
@@ -227,6 +282,7 @@ export default function CreateActivityPage() {
   };
 
   const onSubmit = async (data: ActivityFormData) => {
+    hasSubmittedRef.current = true;
     setIsSubmitting(true);
     setSubmitStatus(null);
 
@@ -348,14 +404,17 @@ export default function CreateActivityPage() {
               <ImageUpload
                 ref={imageUploadRef}
                 value={imageId}
-                onChange={(storageId) => setValue("imageId", storageId)}
+                onChange={(storageId) =>
+                  setValue("imageId", storageId, { shouldDirty: true })
+                }
+                onExtracted={handleExtracted}
               />
               <Text size="1" color="gray" mt="1">
                 Add an image to your activity (optional)
               </Text>
             </div>
 
-            <div>
+            <div style={highlightStyle("name")}>
               <Text size="2" weight="medium" mb="2">
                 Name *
               </Text>
@@ -377,7 +436,9 @@ export default function CreateActivityPage() {
                 {!isSignedIn && <Lock size={14} className="text-gray-400" />}
                 <Switch
                   checked={isPublic}
-                  onCheckedChange={(checked) => setValue("isPublic", checked)}
+                  onCheckedChange={(checked) =>
+                    setValue("isPublic", checked, { shouldDirty: true })
+                  }
                   disabled={!isSignedIn}
                 />
                 <Text
@@ -403,7 +464,7 @@ export default function CreateActivityPage() {
               </Text>
             </div>
 
-            <div>
+            <div style={highlightStyle("description")}>
               <Text size="2" weight="medium" mb="2">
                 Description
               </Text>
@@ -430,7 +491,7 @@ export default function CreateActivityPage() {
                 size="3"
                 disabled={!isSignedIn}
                 onValueChange={(value: "low" | "medium" | "high") =>
-                  setValue("urgency", value)
+                  setValue("urgency", value, { shouldDirty: true })
                 }
               >
                 <SegmentedControl.Item value="low">Low</SegmentedControl.Item>
@@ -460,9 +521,11 @@ export default function CreateActivityPage() {
                 value={watch("location")?.name || ""}
                 onChange={(value, place) => {
                   if (place) {
-                    setValue("location", placeToLocation(place, value));
+                    setValue("location", placeToLocation(place, value), {
+                      shouldDirty: true,
+                    });
                   } else {
-                    setValue("location.name", value);
+                    setValue("location.name", value, { shouldDirty: true });
                   }
                 }}
                 placeholder="Enter location"
@@ -485,13 +548,15 @@ export default function CreateActivityPage() {
               </Flex>
             </div>
 
-            <div>
+            <div style={highlightStyle("tags")}>
               <Text size="2" weight="medium" mb="2">
                 Tags
               </Text>
               <TagCombobox
                 value={tags}
-                onChange={(tags) => setValue("tags", tags)}
+                onChange={(tags) =>
+                  setValue("tags", tags, { shouldDirty: true })
+                }
                 placeholder="Add tags (comma-separated)..."
               />
               <Text size="1" color="gray" mt="1">
@@ -525,12 +590,12 @@ export default function CreateActivityPage() {
               </Text>
             </div>
 
-            <div>
+            <div style={highlightStyle("rainApproved")}>
               <Flex align="center" gap="3">
                 <Switch
                   checked={rainApproved}
                   onCheckedChange={(checked) =>
-                    setValue("rainApproved", checked)
+                    setValue("rainApproved", checked, { shouldDirty: true })
                   }
                 />
                 <Text size="2" weight="medium">
@@ -544,11 +609,13 @@ export default function CreateActivityPage() {
               </Text>
             </div>
 
-            <div>
+            <div style={highlightStyle("inHome")}>
               <Flex align="center" gap="3">
                 <Switch
                   checked={inHome}
-                  onCheckedChange={(checked) => setValue("inHome", checked)}
+                  onCheckedChange={(checked) =>
+                    setValue("inHome", checked, { shouldDirty: true })
+                  }
                 />
                 <Text size="2" weight="medium">
                   In Home
@@ -562,7 +629,14 @@ export default function CreateActivityPage() {
             </div>
 
             <Flex gap="3" justify="end" mt="4">
-              <Button type="button" variant="soft" onClick={() => reset()}>
+              <Button
+                type="button"
+                variant="soft"
+                onClick={() => {
+                  hasSubmittedRef.current = false;
+                  reset();
+                }}
+              >
                 Reset
               </Button>
               <Button

--- a/components/ImageUpload.tsx
+++ b/components/ImageUpload.tsx
@@ -1,33 +1,62 @@
 "use client";
 
 import { useState, useRef, useImperativeHandle, forwardRef } from "react";
-import { useMutation } from "convex/react";
+import { useAction, useMutation } from "convex/react";
 import { api } from "@/convex/_generated/api";
-import { Button, Flex, Text, Box, Callout } from "@radix-ui/themes";
+import { Button, Flex, Text, Box, Callout, Spinner } from "@radix-ui/themes";
 import { Camera, Upload, X, AlertCircle } from "lucide-react";
 import type { Id } from "@/convex/_generated/dataModel";
 import { compressImage } from "@/lib/compressImage";
 import { otel } from "@/lib/otel";
 
+/** Fields the LLM extracts from the image to pre-fill the create form. */
+export type ExtractedActivity = {
+  name: string | null;
+  description: string | null;
+  tags: string[] | null;
+  rainApproved: boolean | null;
+  inHome: boolean | null;
+};
+
 interface ImageUploadProps {
   value?: Id<"_storage">;
   onChange: (storageId: Id<"_storage"> | undefined) => void;
   onPendingImageChange?: (hasPendingImage: boolean) => void;
+  onExtracted?: (data: ExtractedActivity) => void;
 }
 
 export interface ImageUploadHandle {
   uploadPendingImage: () => Promise<void>;
 }
 
+/** Read a Blob (compressed webp or raw File fallback) as a base64 data URL. */
+function blobToDataUrl(blob: Blob): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onloadend = () => resolve(reader.result as string);
+    reader.onerror = () => reject(reader.error);
+    reader.readAsDataURL(blob);
+  });
+}
+
+// Drop the "Analyzing…" state if extraction hasn't returned by this point.
+const EXTRACTION_TIMEOUT_MS = 25_000;
+// Defensive guard vs Convex's ~1MB single-string argument limit.
+const MAX_EXTRACTION_DATA_URL_LENGTH = 900_000;
+
 const ImageUpload = forwardRef<ImageUploadHandle, ImageUploadProps>(
-  ({ value, onChange, onPendingImageChange }, ref) => {
+  ({ value, onChange, onPendingImageChange, onExtracted }, ref) => {
     const [selectedImage, setSelectedImage] = useState<File | null>(null);
     const [previewUrl, setPreviewUrl] = useState<string | null>(null);
     const [isUploading, setIsUploading] = useState(false);
+    const [isAnalyzing, setIsAnalyzing] = useState(false);
     const fileInputRef = useRef<HTMLInputElement>(null);
     const cameraInputRef = useRef<HTMLInputElement>(null);
 
     const generateUploadUrl = useMutation(api.activities.generateUploadUrl);
+    const extractActivity = useAction(
+      api.imageExtraction.extractActivityFromImage,
+    );
 
     const handleFileSelect = (file: File) => {
       if (!file.type.startsWith("image/")) {
@@ -47,26 +76,62 @@ const ImageUpload = forwardRef<ImageUploadHandle, ImageUploadProps>(
       onPendingImageChange?.(true);
     };
 
+    // Fire the LLM extraction in parallel with the storage upload. Owns its own
+    // state and must NEVER block or fail the upload/submit. Silent on error.
+    const runExtraction = async (body: Blob) => {
+      try {
+        const dataUrl = await blobToDataUrl(body);
+        if (dataUrl.length > MAX_EXTRACTION_DATA_URL_LENGTH) {
+          otel.log("warn", "Skipping image extraction: image too large", {
+            length: dataUrl.length,
+          });
+          return;
+        }
+
+        const timeout = new Promise<null>((resolve) =>
+          setTimeout(() => resolve(null), EXTRACTION_TIMEOUT_MS),
+        );
+        const extracted = await Promise.race([
+          extractActivity({ imageBase64: dataUrl }),
+          timeout,
+        ]);
+
+        if (extracted) {
+          onExtracted?.(extracted);
+        }
+      } catch (error) {
+        otel.captureException(error, { context: "image_extraction" });
+      } finally {
+        setIsAnalyzing(false);
+      }
+    };
+
     const handleUpload = async () => {
       if (!selectedImage) return;
 
       setIsUploading(true);
+
+      // Compress once; the same Blob feeds both the upload and the extraction.
+      let body: Blob = selectedImage;
+      let contentType = selectedImage.type;
       try {
-        // Get upload URL
+        body = await compressImage(selectedImage);
+        contentType = "image/webp";
+      } catch (err) {
+        console.error("Image compression failed, uploading raw file:", err);
+        otel.captureException(err, { context: "image_compression" });
+      }
+
+      // Kick off extraction concurrently. Auth is enforced server-side, so this
+      // is a no-op for signed-out users (the action throws and we swallow it).
+      if (onExtracted) {
+        setIsAnalyzing(true);
+        void runExtraction(body);
+      }
+
+      // Upload owns isUploading and clears it as soon as the storageId returns.
+      try {
         const uploadUrl = await generateUploadUrl();
-
-        // Compress before uploading
-        let body: Blob = selectedImage;
-        let contentType = selectedImage.type;
-        try {
-          body = await compressImage(selectedImage);
-          contentType = "image/webp";
-        } catch (err) {
-          console.error("Image compression failed, uploading raw file:", err);
-          otel.captureException(err, { context: "image_compression" });
-        }
-
-        // Upload file
         const result = await fetch(uploadUrl, {
           method: "POST",
           headers: { "Content-Type": contentType },
@@ -174,6 +239,15 @@ const ImageUpload = forwardRef<ImageUploadHandle, ImageUploadProps>(
               <Text size="2" color="green" mt="2">
                 ✓ Image uploaded successfully
               </Text>
+            )}
+
+            {isAnalyzing && (
+              <Flex align="center" gap="2" mt="2">
+                <Spinner size="1" />
+                <Text size="2" color="gray">
+                  ✨ Analyzing image to pre-fill fields…
+                </Text>
+              </Flex>
             )}
           </Box>
         ) : (

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -15,6 +15,7 @@ import type * as embeddings from "../embeddings.js";
 import type * as env from "../env.js";
 import type * as formatting from "../formatting.js";
 import type * as geocoding from "../geocoding.js";
+import type * as imageExtraction from "../imageExtraction.js";
 import type * as imageProcessing from "../imageProcessing.js";
 import type * as importing from "../importing.js";
 import type * as migrations from "../migrations.js";
@@ -43,6 +44,7 @@ declare const fullApi: ApiFromModules<{
   env: typeof env;
   formatting: typeof formatting;
   geocoding: typeof geocoding;
+  imageExtraction: typeof imageExtraction;
   imageProcessing: typeof imageProcessing;
   importing: typeof importing;
   migrations: typeof migrations;

--- a/convex/imageExtraction.ts
+++ b/convex/imageExtraction.ts
@@ -1,0 +1,115 @@
+import { v } from "convex/values";
+import { action } from "./_generated/server";
+import { env } from "./env";
+import OpenAI from "openai";
+import { zodTextFormat } from "openai/helpers/zod";
+import { z } from "zod";
+import { otelServer } from "./otelServer";
+
+// Single swappable model constant. Verified valid against the live API.
+// Fallback: gpt-5 (also a reasoning model, supports `reasoning.effort`).
+// NOTE: gpt-4.1-mini / gpt-4o-mini do NOT support `reasoning.effort` — switching
+// to a non-reasoning model requires removing the `reasoning` field below.
+const EXTRACTION_MODEL = "gpt-5-mini";
+// Keep below the client's 25s drop so the action self-resolves first.
+const OPENAI_REQUEST_TIMEOUT_MS = 20_000;
+
+const OpenAIClient = new OpenAI({ apiKey: env.OPENAI_API_KEY });
+
+// Structured output schema. Every field is nullable so the model can decline
+// anything it cannot confidently read from the image.
+const ExtractionSchema = z.object({
+  name: z.string().nullable(),
+  description: z.string().nullable(),
+  tags: z.array(z.string()).nullable(),
+  rainApproved: z.boolean().nullable(),
+  inHome: z.boolean().nullable(),
+});
+
+const SYSTEM_PROMPT = `You extract structured event details from a single image. The image will either be of an event flyer or poster or of an activity.
+
+if the image is of a flyer or poster, try to extract the text.
+
+if it's of an activity, generate a name and description (1 or 2 lines) that would describe the activity
+
+use null for anything missing or ambiguous.
+- name: the event/activity title as printed. null if unclear.
+- description: a 1-2 sentence summary of what the event is. null if you cannot summarize.
+- tags: free-form lowercase category keywords (e.g. "music", "kids", "art", "food", "outdoor").
+  One tag per category, no synonyms or near-duplicates (pick the single best word).
+  Cap at 5 tags; prefer fewer, high-signal tags.
+  DO NOT include "rain approved", "rain-approved", "at home", "in home", "indoor", or
+  "outdoor location" phrasing here — those are captured by the boolean fields below.
+- rainApproved: true only if the flyer clearly indicates the activity works in rain /
+  is weatherproof / explicitly "rain or shine". null if unstated.
+- inHome: true only if this is explicitly an at-home / online / virtual activity. null if unstated.
+Output strictly matches the provided JSON schema.`;
+
+/**
+ * Extract activity fields from a flyer/poster image for pre-filling the Create
+ * Activity form. Image bytes are passed inline as a base64 data URL so the call
+ * never waits on storage upload. Requires a signed-in user (cheap abuse
+ * protection on the public /tt/create route). Throws on any failure — the client
+ * treats failures silently and never blocks image upload or form submission.
+ */
+export const extractActivityFromImage = action({
+  args: { imageBase64: v.string() },
+  returns: v.object({
+    name: v.union(v.string(), v.null()),
+    description: v.union(v.string(), v.null()),
+    tags: v.union(v.array(v.string()), v.null()),
+    rainApproved: v.union(v.boolean(), v.null()),
+    inHome: v.union(v.boolean(), v.null()),
+  }),
+  handler: async (ctx, args) => {
+    const identity = await ctx.auth.getUserIdentity();
+    if (!identity) {
+      throw new Error("Unauthorized: sign in to extract activity from image");
+    }
+
+    try {
+      const response = await OpenAIClient.responses.parse(
+        {
+          model: EXTRACTION_MODEL,
+          reasoning: { effort: "low" },
+          input: [
+            { role: "system", content: SYSTEM_PROMPT },
+            {
+              role: "user",
+              content: [
+                {
+                  type: "input_text",
+                  text: "Extract the activity details from this image.",
+                },
+                {
+                  type: "input_image",
+                  image_url: args.imageBase64,
+                  detail: "auto",
+                },
+              ],
+            },
+          ],
+          text: {
+            format: zodTextFormat(ExtractionSchema, "activity_extraction"),
+          },
+        },
+        { timeout: OPENAI_REQUEST_TIMEOUT_MS },
+      );
+
+      const parsed = response.output_parsed;
+      return {
+        name: parsed?.name ?? null,
+        description: parsed?.description ?? null,
+        tags: parsed?.tags ?? null,
+        rainApproved: parsed?.rainApproved ?? null,
+        inHome: parsed?.inHome ?? null,
+      };
+    } catch (error) {
+      console.error("extractActivityFromImage failed", error);
+      await otelServer.captureException(ctx, error, {
+        context: "extract_activity_from_image",
+      });
+      throw error;
+    }
+  },
+});

--- a/convex/otelServer.ts
+++ b/convex/otelServer.ts
@@ -33,6 +33,28 @@ export const sendCapture = internalAction({
   handler: async (_ctx, args) => {
     const key = process.env.POSTHOG_KEY;
     if (!key) return;
+
+    // Reconstruct PostHog's reserved `$exception_list` shape here. The wrapper
+    // passes a plain `exception` object because `$`-prefixed keys are illegal in
+    // Convex scheduler args.
+    let properties = args.properties as Record<string, unknown> | undefined;
+    if (args.event === "$exception" && properties?.exception) {
+      const { exception, ...rest } = properties as {
+        exception: { type?: string; value?: string; stacktrace?: string };
+      } & Record<string, unknown>;
+      properties = {
+        ...rest,
+        $exception_list: [
+          {
+            type: exception.type,
+            value: exception.value,
+            stacktrace: exception.stacktrace,
+            mechanism: { handled: true, synthetic: false },
+          },
+        ],
+      };
+    }
+
     try {
       await fetch(`${POSTHOG_HOST}/capture/`, {
         method: "POST",
@@ -41,7 +63,7 @@ export const sendCapture = internalAction({
           api_key: key,
           event: args.event,
           distinct_id: args.distinctId,
-          properties: args.properties,
+          properties,
         }),
       });
     } catch (err) {
@@ -71,15 +93,15 @@ export const otelServer = {
   ): Promise<void> {
     const distinctId = await getDistinctId(ctx);
     const err = error instanceof Error ? error : new Error(String(error));
+    // Convex scheduler args cannot contain `$`-prefixed field names, so we pass a
+    // plain `exception` object here and reshape it into PostHog's reserved
+    // `$exception_list` property inside `sendCapture` (plain JSON, where `$` is ok).
     await schedule(ctx, "$exception", distinctId, {
-      $exception_list: [
-        {
-          type: err.name,
-          value: err.message,
-          stacktrace: err.stack,
-          mechanism: { handled: true, synthetic: false },
-        },
-      ],
+      exception: {
+        type: err.name,
+        value: err.message,
+        stacktrace: err.stack,
+      },
       ...properties,
     });
   },

--- a/docs/adr/0002-image-llm-form-prefill.md
+++ b/docs/adr/0002-image-llm-form-prefill.md
@@ -1,0 +1,118 @@
+# ADR 0002 — Image → LLM form prefill on Create Activity
+
+- **Status**: Accepted
+- **Date**: 2026-06-25
+
+## Context
+
+Creating an activity from a flyer/poster means re-typing what's already printed
+on the image. We want to extract the obvious fields (title, blurb, a few tags,
+the rain/at-home flags) with an LLM and pre-fill the create form, without slowing
+the page down or ever overwriting what the user has typed. The full design lives
+in [`docs/image-llm-prefill-prd.md`](../image-llm-prefill-prd.md); this ADR
+records the architecturally-significant choices and the ones refined at build
+time.
+
+Constraints audited up-front:
+
+- `/tt/create` is **not** behind `middleware.ts` auth — a naive extraction
+  endpoint is an open, billable OpenAI proxy.
+- The form (`app/tt/create/page.tsx`) is React Hook Form but sets every
+  non-text field via bare `setValue(...)` with **no dirty tracking**; `name`/
+  `description`/`endDate`/`sourceUrl` use `register` (auto-dirty on type).
+- `location` is a structured Google Places object with a `placeId` the LLM
+  can't produce; `rainApproved`/`inHome` are booleans the form maps to the
+  special `"rain approved"`/`"at home"` tags on submit.
+- OpenAI is the only LLM wired (`openai@6.18.0`, `text-embedding-3-small`
+  embeddings in `convex/activities.ts`, default Convex runtime — no `"use node"`).
+
+## Decision
+
+1. **Parallelized, inline extraction.** On "Confirm & Upload", compress once,
+   then run the existing storage upload **and** a new `extractActivityFromImage`
+   action concurrently. The action takes image bytes inline as a base64 data URL
+   (`{ imageBase64 }`), so it never waits on `storageId`. Net added latency ≈ one
+   LLM round-trip, overlapped with the upload.
+
+2. **Auth-gated action.** `extractActivityFromImage` throws if
+   `ctx.auth.getUserIdentity()` is null. Auto-fill is a signed-in bonus; signed-
+   out users still upload + fill manually. Cheap abuse protection on a public
+   route, without per-IP rate limiting (deferred).
+
+3. **`gpt-5-mini` via the Responses API + Structured Outputs.** `responses.parse`
+   with `zodTextFormat(schema, …)` (from `openai/helpers/zod`, zod v4); read
+   `output_parsed`. Low reasoning effort, 20s request timeout. The model is a
+   single swappable constant (`EXTRACTION_MODEL`) — if it's unavailable the
+   action throws and the feature degrades silently.
+
+4. **Extract five nullable fields:** `name`, `description`, `tags` (free-form,
+   lowercase, one-per-category, excludes the rain/at-home tags), `rainApproved`,
+   `inHome`. The model omits anything it can't confidently read.
+
+5. **Merge via `reset(..., { keepDirtyValues: true })` + a `shouldDirty`
+   retrofit.** `handleExtracted` calls
+   `reset({ ...getValues(), ...definedExtracted }, { keepDirtyValues: true })`.
+   Because the form previously didn't mark `setValue` edits dirty, we added
+   `{ shouldDirty: true }` to **every** manual `setValue` handler so user-touched
+   fields are recognised as dirty and preserved. Spreading `getValues()` keeps
+   untouched non-extracted fields (notably the just-uploaded `imageId`) from
+   being wiped. A `hasSubmittedRef` guard drops results that arrive after submit.
+
+6. **Fail safe.** The action throws on any OpenAI error (server-side
+   `otelServer` capture); the client catches silently (`otel`), runs a 25s
+   timeout race, and never blocks upload or submit. Empty result → no-op.
+   Auto-filled fields get a brief highlight.
+
+## Alternatives considered
+
+- **Conditional per-field `setValue`** (read `getValues()`, fill each field only
+  when empty) instead of `reset` + `keepDirtyValues`. Equivalent end behaviour
+  and a smaller diff, but the owner chose to keep the PRD's `reset` mechanism;
+  the `shouldDirty` retrofit makes it correct. Trade-off accepted: toggling a
+  boolean on→off returns it to the default value, which RHF re-marks clean, so
+  extraction could re-fill it (rare).
+- **Pass `storageId` and have the action fetch the stored image.** Rejected —
+  serializes extraction behind the upload and adds a storage round-trip. Inline
+  base64 (~hundreds of KB + 33%, well under Convex's ~1MB single-string arg
+  limit) is smaller and parallelizable. A `MAX_EXTRACTION_DATA_URL_LENGTH` guard
+  skips oversized payloads.
+- **Chat Completions `parse`** instead of the Responses API. Either works in
+  `openai@6`; Responses + `zodTextFormat` is the current-generation path and
+  what the SDK steers toward.
+- **Return all-nulls on OpenAI error** instead of throwing. Rejected — conflates
+  "extraction failed" with "nothing extractable" and weakens telemetry. The
+  client already treats failures as a silent no-op, so throwing is safe.
+- **Extract `location`/`endDate`/`urgency`.** Out of scope (v1) — `location`
+  needs a `placeId` the model can't produce; the rest are low-value for flyers.
+
+## Consequences
+
+**Positive**
+
+- Perceived latency is just the upload; extraction overlaps and surfaces its own
+  "Analyzing…" indicator.
+- No new dependency or runtime: reuses `openai`, `zod`, the existing
+  `OPENAI_API_KEY`, and the default Convex runtime.
+- Auth gate removes the obvious credit-burn vector without blocking the public
+  upload flow.
+
+**Negative / accepted trade-offs**
+
+- `gpt-5-mini` + Responses structured-output availability is unverified in this
+  ADR — must be confirmed against the live OpenAI account before shipping;
+  mitigated by the swappable constant + silent-degrade path.
+- The `shouldDirty` retrofit touches every manual `setValue` in the create form.
+- The 25s client timeout doesn't cancel the in-flight Convex action; the 20s
+  server-side OpenAI timeout caps it just below.
+- Free-form tags can drift over time; the one-tag-per-category prompt rule
+  reduces but doesn't eliminate this. Constrained vocabulary deferred.
+
+## Implementation references
+
+- Action: [`convex/imageExtraction.ts`](../../convex/imageExtraction.ts) —
+  `extractActivityFromImage`.
+- Trigger + orchestration: [`components/ImageUpload.tsx`](../../components/ImageUpload.tsx)
+  — `handleUpload` (compress once, parallel upload + `runExtraction`).
+- Merge: [`app/tt/create/page.tsx`](../../app/tt/create/page.tsx) —
+  `handleExtracted`, the `shouldDirty` retrofit, `hasSubmittedRef` guard.
+- Product spec: [`docs/image-llm-prefill-prd.md`](../image-llm-prefill-prd.md).

--- a/docs/image-llm-prefill-prd.md
+++ b/docs/image-llm-prefill-prd.md
@@ -1,0 +1,148 @@
+# PRD — Image → LLM Form Prefill (Create Activity)
+
+**Status:** Approved for implementation
+**Owner:** kev4tech@gmail.com
+**Last updated:** 2026-06-24
+**Branch:** `claude/image-llm-form-prefill-i6w71t`
+
+## Summary
+
+On the Create Activity page (`app/tt/create/page.tsx`), when a user uploads an
+image (e.g. an event flyer or poster), send that image to an LLM and use the
+returned structured output to pre-fill empty fields of the create form. The goal
+is to save the user typing while never overwriting anything they've already
+entered, and to keep the interaction as fast as possible.
+
+## Goals
+
+- Reduce manual data entry when creating an activity from a flyer/poster/photo.
+- Pre-fill **only** fields the user hasn't touched.
+- Keep perceived latency minimal by overlapping the LLM call with the existing
+  image upload.
+- Fail safe: extraction problems never block image upload or form submission.
+
+## Non-goals (v1)
+
+- Extracting `location` (form uses a structured Google Places object with a
+  `placeId` the LLM cannot produce), `endDate`, `urgency`, `sourceUrl`,
+  `isPublic`.
+- Constrained/curated tag vocabulary (free-form for now).
+- Rate limiting / IP throttling beyond requiring authentication.
+- Re-running extraction on the auto-upload-at-submit path.
+
+## Current behavior (context)
+
+- **Form** (`app/tt/create/page.tsx`): React Hook Form, fields `name`,
+  `description`, `urgency`, `location`, `endDate`, `isPublic`, `rainApproved`,
+  `inHome`, `tags[]`, `imageId`, `sourceUrl`. `rainApproved`/`inHome` are booleans
+  the form maps to the special tags `"rain approved"` / `"at home"` on submit.
+- **Image upload** (`components/ImageUpload.tsx`): user selects a file →
+  preview shown (pending) → optional **"Confirm & Upload"** button
+  (`handleUpload`) compresses to WebP (`lib/compressImage.ts`) and uploads to
+  Convex storage via `api.activities.generateUploadUrl`, returning a `storageId`.
+  If skipped, the image auto-uploads on form submit.
+- **AI today**: OpenAI only (`text-embedding-3-small` for embeddings in
+  `convex/activities.ts`). `openai` v6 SDK + `OPENAI_API_KEY` already wired.
+- **Tags**: stored in a `tags` table, queried via `api.tags.listTags`; the
+  `TagCombobox` is hybrid (suggest existing + free-form create). Tags are
+  normalized (trim + lowercase + dedupe) on write in `createActivityDocument`.
+
+## Design decisions
+
+### 1. Model & API
+- Use **`gpt-5-mini`** (OpenAI) with **vision input + Structured Outputs**, via
+  the existing `openai` v6 client and `OPENAI_API_KEY`.
+- Use **low reasoning effort** for speed.
+- Prefer the SDK structured-output helper (`responses.parse`); fall back to
+  JSON-schema mode if the installed SDK version requires it. Confirm at build.
+
+### 2. Trigger & parallelized flow
+- Extraction fires when the user presses **"Confirm & Upload"** in
+  `ImageUpload` (deliberate action → no surprise token spend).
+- Compress the image **once**, then run two calls **in parallel**:
+  1. **Storage upload** → `generateUploadUrl` → `fetch` → `storageId`
+     (existing path; populates `imageId`).
+  2. **Extraction** → new Convex action
+     `extractActivityFromImage({ imageBase64 })` → OpenAI → structured output.
+- The LLM call does **not** depend on `storageId` (image bytes are passed inline
+  as a base64 data URL), so it never waits on the upload. Compressed WebP is
+  small (~hundreds of KB + ~33% base64), comfortably within Convex action arg
+  limits.
+- Net added latency ≈ one LLM round-trip, overlapped with the upload.
+
+### 3. Auth
+- `extractActivityFromImage` calls `ctx.auth.getUserIdentity()` and throws if
+  the user is not signed in. Auto-fill is a signed-in-only bonus; signed-out
+  users can still upload images and fill the form manually. This removes the
+  obvious credit-burn vector on a public route (`/tt/create` is not behind
+  `middleware.ts` auth).
+
+### 4. Extracted fields
+All fields nullable; the model omits anything it cannot read from the image.
+
+| Field          | Type      | Notes |
+| -------------- | --------- | ----- |
+| `name`         | string?   | Event/activity title. |
+| `description`  | string?   | Short summary from the image. |
+| `tags`         | string[]? | Free-form. **Excludes** `"rain approved"`/`"at home"` (those come from the booleans). |
+| `rainApproved` | boolean?  | Inferred (weather-independent / works in rain). |
+| `inHome`       | boolean?  | Inferred (doable at home / indoor). |
+
+**Tag rule (in the prompt + schema description):** one tag per category, no
+synonyms — e.g. `kids` **or** `family-friendly` (not both), plus a tag from a
+different dimension such as `food`, `outdoor`, etc. Cap to a small set.
+
+### 5. Merge into the form
+- Apply extracted values with **`reset(extracted, { keepDirtyValues: true })`**.
+  This fills only fields the user hasn't touched (works uniformly for text,
+  tags, and the booleans — `dirtyFields` semantics).
+- If extraction returns **after** the form is already submitted, drop the result
+  (no-op).
+
+### 6. UX
+- **Loading:** inline "✨ Analyzing image…" indicator, independent of the
+  image's own upload state. The "Confirm & Upload" button completes as soon as
+  `storageId` returns; extraction shows its own indicator.
+- **Failure** (OpenAI error/timeout): silent + `otel.captureException`; never
+  blocks upload or submit. Optional tiny dismissible "Couldn't auto-fill from
+  image" note.
+- **Empty result:** no-op (no error shown).
+- **Success:** briefly highlight the fields that were auto-filled so the user
+  notices what changed.
+- **Timeout:** ~25s; on timeout, drop the "Analyzing…" state silently.
+
+## Architecture / files to touch
+
+- **`convex/activities.ts`** (or a new `convex/imageExtraction.ts`): add
+  `extractActivityFromImage` action — `"use node"`, auth check, OpenAI vision
+  call with structured-output schema, returns the typed object.
+- **`components/ImageUpload.tsx`**: compress once; fire upload + extraction in
+  parallel inside `handleUpload`; add `onExtracted(data)` prop to bubble results
+  up; add the "Analyzing…" indicator and silent error handling.
+- **`app/tt/create/page.tsx`**: pass `onExtracted` to `ImageUpload`; on result,
+  call `reset(extracted, { keepDirtyValues: true })`; add the auto-filled-field
+  highlight cue.
+
+## Open implementation details (decided by implementer)
+
+- Orchestration lives **inside `ImageUpload`** (it owns the compressed blob +
+  upload); the page does the `reset()`.
+- Exact structured-output mechanism (`responses.parse` vs JSON-schema mode)
+  confirmed against the installed `openai` SDK at build time.
+
+## Risks
+
+- **Cost/abuse:** mitigated for v1 by requiring auth; revisit rate limiting if
+  abuse appears.
+- **Model/SDK drift:** `gpt-5-mini` and Responses-API structured outputs must be
+  available in the installed SDK; verify and fall back gracefully.
+- **Tag fragmentation:** free-form tags can drift over time; the one-tag-per-
+  category prompt rule reduces but doesn't eliminate this. A constrained
+  vocabulary is a future enhancement.
+
+## Future enhancements
+
+- Constrained-but-extensible tag vocabulary seeded from `listTags`.
+- Extract `endDate`/`location` (address string hint, not the structured field).
+- Per-user rate limiting on the extraction action.
+- Fire extraction on image **select** (not just upload) for earlier prefill.


### PR DESCRIPTION
## Summary

Implements image → LLM form prefill on the Create Activity page. When a signed-in user uploads a flyer/poster and clicks **"Confirm & Upload"**, the image is compressed once, then the storage upload and a new OpenAI vision extraction run **in parallel**. The structured result pre-fills **only untouched** form fields and never blocks image upload or form submission.

This PR began as the docs-only PRD (`docs/image-llm-prefill-prd.md`) and now includes the implementation, an ADR, and a fix to a shared telemetry bug surfaced during testing.

## What's included

- **`convex/imageExtraction.ts`** (new) — auth-gated `extractActivityFromImage({ imageBase64 })` action. `gpt-5-mini` via the Responses API + `zodTextFormat` Structured Outputs; nullable `name`/`description`/`tags`/`rainApproved`/`inHome`; `otelServer` + `console.error` on failure; 20s request timeout. Model is a single swappable constant.
- **`components/ImageUpload.tsx`** — new `onExtracted` prop + independent `isAnalyzing` state. Compress once, then upload + extract concurrently; the upload button clears as soon as `storageId` returns while extraction shows its own "✨ Analyzing…" indicator. 25s client timeout; failures are silent + logged, never blocking.
- **`app/tt/create/page.tsx`** — `reset({ ...getValues(), ...extracted }, { keepDirtyValues: true })` merge. Retrofitted `{ shouldDirty: true }` onto every manual `setValue` handler so user-touched fields are protected and the uploaded `imageId` survives the reset. `hasSubmittedRef` guard drops results that arrive after submit; transient highlight on auto-filled fields.
- **`convex/otelServer.ts`** (fix) — `captureException` was putting PostHog's reserved `$exception_list` key directly into Convex scheduler args, which forbids `$`-prefixed field names. The capture call threw inside callers' catch blocks, masking the real error and breaking **all** backend exception capture. The `$exception_list` shape is now assembled inside `sendCapture` (plain JSON).
- **`docs/adr/0002-image-llm-form-prefill.md`** (new) — ADR pairing the PRD, recording the key decisions.

## Key decisions

- **Auth-gated** extraction (throws if signed-out) — cheap abuse protection on the public `/tt/create` route.
- **Inline base64** image bytes so extraction never waits on `storageId`; well under Convex's ~1MB single-string arg limit, with a defensive size guard.
- **Merge via `reset` + `keepDirtyValues`** (per the PRD), made correct by the `shouldDirty` retrofit.
- **Throw on error**; the client treats failures as a silent no-op.

## Verification

- ✅ `tsc --noEmit` clean; `next lint` clean (one pre-existing `<img>` warning).
- ✅ Action bundles + deploys (validated via `convex codegen`).
- ✅ Model/API shape verified against the live API: `gpt-5-mini` is valid and `responses.parse` + `reasoning.effort` + `zodTextFormat` work.
- ⚠️ End-to-end extraction currently returns `429 insufficient_quota` — the OpenAI account behind `OPENAI_API_KEY` needs billing/credits. Not a code issue; the feature degrades silently until credits are added.

## Out of scope (v1)

`location`/`endDate`/`urgency`/`sourceUrl`/`isPublic` extraction, constrained tag vocabulary, per-IP rate limiting, re-running extraction on the auto-upload-at-submit path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
